### PR TITLE
Generate builds so they can be used in server rendered apps

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -13,6 +13,7 @@ module.exports = Merge.smart(commonConfig, {
     path: path.resolve(__dirname, '../dist'),
     library: 'frontend-component-footer',
     libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
Without setting this, `npm run build` generates packages that use `window`. Changing it to `this` would make it web and server friendly. The addition of the `self` check is what all the other packages that use this do to support modules (?). I don't know enough to know if we need it, but might as well that as well. 