### PR TITLE
fix: non deprecated use of hyperlink

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,4 @@
-@import "~@edx/edx-bootstrap/sass/edx/theme";
+@import "~@edx/edx-bootstrap/scss/edx/theme";
 @import "~bootstrap/scss/bootstrap";
 
 @import './lib/scss/_site-footer.scss';

--- a/src/lib/components/SiteFooter/index.jsx
+++ b/src/lib/components/SiteFooter/index.jsx
@@ -120,9 +120,10 @@ class SiteFooter extends React.Component {
           <div className="area-1">
             <Hyperlink
               destination={marketingSiteBaseUrl}
-              content={<img src={siteLogo.src} alt={siteLogo.altText} />}
               aria-label={siteLogo.ariaLabel}
-            />
+            >
+              <img src={siteLogo.src} alt={siteLogo.altText} />
+            </Hyperlink>
             {showLanguageSelector &&
               <div className="i18n d-flex mt-2">
                 <form


### PR DESCRIPTION
Also there was a bad path to the edx-bootstrap scss theme file?  No idea how we missed that for so long.