### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ Build the component::
 
    npm run build
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-component-footer.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-component-footer
+.. |Build Status| image:: https://api.travis-ci.com/edx/frontend-component-footer.svg?branch=master
+   :target: https://travis-ci.com/edx/frontend-component-footer
 .. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-component-footer.svg?branch=master
    :target: https://coveralls.io/github/edx/frontend-component-footer
 .. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-component-footer.svg


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089