### PR TITLE
fix: remove unnecessary paragon peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^1.8.0",
-    "@edx/paragon": "^7.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
The actual component code doesn’t use paragon.  Only the example app does, meaning this isn’t really a peer dependency.