### PR TITLE
docs: Update training site link

### DIFF
--- a/src/components/studio-footer/help-components/HelpContent.jsx
+++ b/src/components/studio-footer/help-components/HelpContent.jsx
@@ -23,7 +23,7 @@ const BUTTONS = [
   },
   {
     as: 'a',
-    href: 'https://training.openedx.io/courses/course-v1:OpenedX+DemoX+Demo_Course/about',
+    href: 'https://apps.training.openedx.io/catalog/courses/course-v1:OpenedX+DemoX+Demo_Course/about',
     size: 'sm',
     message: messages.openEdxDemoCourseButtonLabel,
     dataTestid: 'openEdXDemoCourseButton',


### PR DESCRIPTION
Since we moved to the catalog MFE on the training site, the correct link to the Demo course is the MFE catalog link

Note: redirects are in place so this link is not broken without this change, but figured it'd be a good idea to make this change nonetheless.